### PR TITLE
Add missing parameter on created hook

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -14,12 +14,14 @@ import JwtDecode from 'jwt-decode';
 export default {
     data() {
         return {
-            authenticated: true
+            authenticated: false
         };
     },
     created: function () {
-        if(localStorage.getItem('jwtToken')!==null) {
-            this.registerToken();
+        const jwtToken = window.localStorage.getItem('jwtToken');
+
+        if(jwtToken!==null) {
+            this.registerToken(jwtToken);
         }
     },
     methods: {


### PR DESCRIPTION
Resloving problem where console says:
```
Object { message: "Invalid token specified", stack: "@http://localhost/athens-ui/athens.…" }
```

The token was not passed as parameter to the registerToken so `JwtDecode` function has `undefined` to parse